### PR TITLE
Fix version of SongOfDoom

### DIFF
--- a/index.json
+++ b/index.json
@@ -6,7 +6,7 @@
   "modpacks": [
     {
       "name": "SongOfDoom",
-      "version": "1.3",
+      "version": "1.4.1",
       "license": "CC-BY-SA-4.0",
       "type": "Musicset",
       "url": "mods/SongOfDoom.json"


### PR DESCRIPTION
I noticed that a incorrect version number is recorded in the index for the SongOfDoom modpack.

After noticing  that, I checked the other modpacks using the following script and found no other instances of version mismatches.

```
#!/bin/sh

IFS='|'
jq -r '.modpacks[] | "\(.name)|\(.version)|\(.url)"' index.json \
	| while read NAME VERSION URL; do
		RVERSION=$({ if $(echo "$URL" | grep -q '^http'); then
			curl -s "$URL"
		else
			cat "$URL"
		fi } | jq -r '.info.version')

		[ "$VERSION" != "$RVERSION" ] \
			&& echo "Version mismatch for \"$NAME\": index $VERSION; remote $RVERSION"
	done
```